### PR TITLE
Import containers when accessing dependencies via `import_module`

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -58,7 +58,7 @@ module Dry
       def self.finalize!(&_block)
         yield(self) if block_given?
 
-        imports.each { |ns, container| import_container(ns, container) }
+        import_containers
 
         Dir[root.join("#{config.core_dir}/boot/**/*.rb")].each do |path|
           boot!(File.basename(path, '.rb').to_sym)
@@ -177,6 +177,10 @@ module Dry
       end
 
       private
+
+      def self.import_containers
+        imports.each { |ns, container| import_container(ns, container) }
+      end
 
       def self.import_container(ns, container)
         container.finalize!

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -73,6 +73,7 @@ module Dry
         auto_inject = Dry::AutoInject(self)
 
         -> *keys {
+          import_containers
           keys.each { |key| load_component(key) unless key?(key) }
           auto_inject[*keys]
         }

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -176,13 +176,23 @@ module Dry
         @imports ||= {}
       end
 
+      def self.imported
+        @imported ||= {}
+      end
+
       private
+
+      def self.imported?(name)
+        imported.key?(name)
+      end
 
       def self.import_containers
         imports.each { |ns, container| import_container(ns, container) }
       end
 
       def self.import_container(ns, container)
+        return if imported?(ns)
+
         container.finalize!
 
         items = container._container.each_with_object({}) { |(key, item), res|
@@ -190,6 +200,8 @@ module Dry
         }
 
         _container.update(items)
+
+        imported[ns] = true
       end
 
       def self.auto_register

--- a/spec/fixtures/importable/lib/test/importable_dep.rb
+++ b/spec/fixtures/importable/lib/test/importable_dep.rb
@@ -1,0 +1,4 @@
+module Test
+  class ImportableDep
+  end
+end

--- a/spec/fixtures/test/lib/test/using_imported.rb
+++ b/spec/fixtures/test/lib/test/using_imported.rb
@@ -1,0 +1,5 @@
+module Test
+  class UsingImported
+    include Import['other.test.importable_dep']
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,12 +33,16 @@ RSpec.configure do |config|
 
   config.before do
     @load_paths = $LOAD_PATH.dup
+    @loaded_features = $LOADED_FEATURES.dup
     Object.const_set(:Test, Module.new { |m| m.extend(TestNamespace) })
   end
 
   config.after do
     ($LOAD_PATH - @load_paths).each do |path|
       $LOAD_PATH.delete(path)
+    end
+    ($LOADED_FEATURES - @loaded_features).each do |feature|
+      $LOADED_FEATURES.delete(feature)
     end
     Test.remove_constants
     Object.send(:remove_const, :Test)

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -5,7 +5,18 @@ RSpec.describe Dry::Component::Container do
 
   context 'with default core dir' do
     before do
+      class Test::ImportableContainer < Dry::Component::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures/importable').realpath
+          config.auto_register = ['lib']
+        end
+
+        load_paths!('lib')
+      end
+
       class Test::Container < Dry::Component::Container
+        import other: Test::ImportableContainer
+
         configure do |config|
           config.root = SPEC_ROOT.join('fixtures/test').realpath
         end
@@ -15,6 +26,15 @@ RSpec.describe Dry::Component::Container do
 
       module Test
         Import = Container.import_module
+      end
+    end
+
+    describe '.import_module' do
+      it 'makes components available from imported containers' do
+        container.require_component 'test.using_imported'
+
+        expect(Test.const_defined?(:ImportableDep)).to be(true)
+        expect(Test::UsingImported.new.importable_dep).to be_instance_of(Test::ImportableDep)
       end
     end
 


### PR DESCRIPTION
I found this bug when working on icelab/alpinist#2 – while the app would work properly when run via the web server, my unit specs were failing because the "core" dependencies (i.e. the ones imported into the `Main::Container` from `Alpinist::Container`) were not being loaded properly. This was because in the unit  specs were (rightly) not finalizing `Main::Container`, in order to test things in isolation and to avoid spuriously loading the whole application environment.

To address this, I've made it so that any imported containers are imported when auto-imported dependencies are accessed from a container's `.import_module`.

_(I'm not 100% sure if this is the approach you'd like to take, @solnic, so I was going to push this up into a branch directly on the dryrb repo so you could potentially make adjustments, but dry-container isn't included in the list of repos I can write to, so I've put it up on a personal fork instead. Let me know if you'd like me to push this anywhere else)._

