### PR TITLE
Require components from imported containers

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -143,6 +143,14 @@ module Dry
           Kernel.require component.path
           yield(component.constant) if block
         else
+          imports.each do |ns, container|
+            begin
+              localized_key = key.sub(/^#{Regexp.escape(ns)}#{Regexp.escape(config.namespace_separator)}/, '')
+              return container.require_component(localized_key, &block)
+            rescue ArgumentError
+            end
+          end
+
           fail ArgumentError, "could not resolve require file for #{key}"
         end
       end

--- a/spec/fixtures/import/lib/test/import_dep.rb
+++ b/spec/fixtures/import/lib/test/import_dep.rb
@@ -1,0 +1,4 @@
+module Test
+  class ImportDep
+  end
+end

--- a/spec/fixtures/test/lib/test/using_import.rb
+++ b/spec/fixtures/test/lib/test/using_import.rb
@@ -1,0 +1,5 @@
+module Test
+  class UsingImport
+    include Import['other.test.import_dep']
+  end
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -5,7 +5,18 @@ RSpec.describe Dry::Component::Container do
 
   context 'with default core dir' do
     before do
+      class Test::ImportContainer < Dry::Component::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures/import').realpath
+          config.auto_register = ['lib']
+        end
+
+        load_paths!('lib')
+      end
+
       class Test::Container < Dry::Component::Container
+        import other: Test::ImportContainer
+
         configure do |config|
           config.root = SPEC_ROOT.join('fixtures/test').realpath
         end
@@ -41,6 +52,15 @@ RSpec.describe Dry::Component::Container do
         expect(Test.const_defined?(:Dep)).to be(true)
 
         expect(Test::Foo.new.dep).to be_instance_of(Test::Dep)
+      end
+
+      it 'requires components from imported containers' do
+        container.require_component('test.using_import')
+
+        expect(Test.const_defined?(:UsingImport)).to be(true)
+        expect(Test.const_defined?(:ImportDep)).to be(true)
+
+        expect(Test::UsingImport.new.import_dep).to be_instance_of(Test::ImportDep)
       end
     end
   end


### PR DESCRIPTION
This implements the approach I suggested at the end of #2:

> Perhaps instead we have .require_component do this:
>
> 1. Try to require the component from the current container (i.e. the current behaviour)
> 2. If this finds nothing (i.e. before we `fail ArgumentError` atm), loop through any yet-to-be-imported containers for the component (taking away the imported container's local name prefix) and try and `.require_component` the dep there.
>
> This way we could load the dep from the other container and avoid finalizing it, which is our preferred behaviour, and we can get rid of the "brute-force" bulk import of all the containers in .import_module. Seems like it'd be cleaner and more direct.

This looks like it works nicely. It gives us dependencies from imported containers in isolation, and allows us to avoid trying to import all the containers wholesale whenever we're auto-injecting a dependency of any kind.

If you're happy with this, we can close #2.