### PR TITLE
Namespaces proof of concept

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -34,6 +34,10 @@ module Dry
         self
       end
 
+      def self.Loader(key)
+        Component.Loader(key)
+      end
+
       def self.import(other)
         case other
         when Dry::Container::Namespace then super
@@ -87,10 +91,10 @@ module Dry
 
         Dir["#{root}/#{dir}/**/*.rb"].each do |path|
           component_path = path.to_s.gsub("#{dir_root}/", '').gsub('.rb', '')
-          Component.Loader(component_path).tap do |component|
+          Loader(component_path).tap do |component|
             next if key?(component.identifier)
 
-            Kernel.require component.path
+            Kernel.require path
 
             if block_given?
               register(component.identifier, yield(component.constant))
@@ -136,7 +140,7 @@ module Dry
       end
 
       def self.load_component(key)
-        component = Component.Loader(key)
+        component = Loader(key)
         src_key = component.namespaces[0]
 
         if imports.key?(src_key)

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -157,14 +157,15 @@ module Dry
       end
 
       def self.require_component(component, &block)
-        path = load_paths.detect { |p| p.join(component.file).exist? }
-
-        if path
+        if root.join(component.file).exist?
+          require component.file
+        elsif path = load_paths.detect { |p| p.join(component.file).exist? }
           Kernel.require component.path
-          yield(component.constant) if block
         else
           fail ArgumentError, "could not resolve require file for #{component.identifier}"
         end
+
+        yield(component.constant) if block
       end
 
       def self.root

--- a/lib/dry/component/loader.rb
+++ b/lib/dry/component/loader.rb
@@ -2,8 +2,8 @@ require 'inflecto'
 
 module Dry
   module Component
-    def self.Loader(input)
-      Loader.new(Loader.identifier(input), Loader.path(input))
+    def self.Loader(input, namespace=nil)
+      Loader.new(Loader.identifier(input), Loader.path(input), namespace)
     end
 
     class Loader
@@ -20,7 +20,8 @@ module Dry
         input.to_s.gsub(IDENTIFIER_SEPARATOR, PATH_SEPARATOR)
       end
 
-      def initialize(identifier, path)
+      def initialize(identifier, path, namespace)
+        @namespace = namespace
         @identifier = identifier
         @path = path
         @file = "#{path}.rb"
@@ -31,7 +32,7 @@ module Dry
       end
 
       def name
-        Inflecto.camelize(path)
+        [@namespace, Inflecto.camelize(path)].compact.join('::')
       end
 
       def constant

--- a/lib/dry/component/namespace.rb
+++ b/lib/dry/component/namespace.rb
@@ -8,6 +8,7 @@ module Dry
         def extended(namespace)
           container = build(namespace)
           namespace.const_set(:Container, container)
+          namespace.const_set(:Import, container.import_module)
 
           namespace.extend SingleForwardable
           namespace.def_delegators container,

--- a/lib/dry/component/namespace.rb
+++ b/lib/dry/component/namespace.rb
@@ -1,0 +1,42 @@
+require 'forwardable'
+require 'dry/component/container'
+
+module Dry
+  module Component
+    module Namespace
+      class <<self
+        def extended(namespace)
+          container = build(namespace)
+          namespace.const_set(:Container, container)
+
+          namespace.extend SingleForwardable
+          namespace.def_delegators container,
+                              :root, :require, :options, :[],
+                              :register, :finalize, :namespace,
+                              :configure, :finalize!
+        end
+
+        def build(namespace)
+          Class.new(Dry::Component::Namespace::Container) do
+            config.namespace = namespace
+          end
+        end
+      end
+
+      class Container < Dry::Component::Container
+        setting :namespace
+
+        class << self
+          def auto_register!(dir, &block)
+            super(['.',dir].join('/'), &block)
+          end
+
+          def Loader(key)
+            key = key.to_s.gsub(/^[\/\.]+/, '')
+            Component.Loader(key, config.namespace)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/namespaced/foos/bar.rb
+++ b/spec/fixtures/namespaced/foos/bar.rb
@@ -1,0 +1,8 @@
+module Tests
+  module Namespaced
+    module Foos
+      class Bar
+      end
+    end
+  end
+end

--- a/spec/fixtures/namespaced/imported.rb
+++ b/spec/fixtures/namespaced/imported.rb
@@ -1,0 +1,6 @@
+module Tests
+  module Namespaced
+    class Imported
+    end
+  end
+end

--- a/spec/fixtures/namespaced/namespace.rb
+++ b/spec/fixtures/namespaced/namespace.rb
@@ -6,5 +6,7 @@ module Tests
       config.root = Pathname(__dir__)
       config.auto_register = 'foos'
     end
+
+    require 'something'
   end
 end

--- a/spec/fixtures/namespaced/namespace.rb
+++ b/spec/fixtures/namespaced/namespace.rb
@@ -1,0 +1,10 @@
+module Tests
+  module Namespaced
+    extend Dry::Component::Namespace
+
+    configure do |config|
+      config.root = Pathname(__dir__)
+      config.auto_register = 'foos'
+    end
+  end
+end

--- a/spec/fixtures/namespaced/something.rb
+++ b/spec/fixtures/namespaced/something.rb
@@ -1,0 +1,11 @@
+module Tests
+  module Namespaced
+    class Something
+      include Tests::Namespaced::Import['imported']
+
+      def call
+        imported
+      end
+    end
+  end
+end

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,0 +1,18 @@
+require 'dry/component/namespace'
+require SPEC_ROOT.join("fixtures/namespaced/namespace")
+
+RSpec.describe Dry::Component::Namespace do
+  subject! { Tests::Namespaced }
+
+  before(:all) do
+    Tests::Namespaced.finalize!
+  end
+
+  it 'defines a container inside the namespace' do
+    expect(Tests::Namespaced::Container).to be_kind_of(Dry::Container::Mixin)
+  end
+
+  it 'auto_register inside the namespace' do
+    expect(subject['foos.bar']).to be_kind_of(Tests::Namespaced::Foos::Bar)
+  end
+end

--- a/spec/unit/namespace_spec.rb
+++ b/spec/unit/namespace_spec.rb
@@ -1,10 +1,10 @@
 require 'dry/component/namespace'
-require SPEC_ROOT.join("fixtures/namespaced/namespace")
 
 RSpec.describe Dry::Component::Namespace do
   subject! { Tests::Namespaced }
 
   before(:all) do
+    require SPEC_ROOT.join("fixtures/namespaced/namespace")
     Tests::Namespaced.finalize!
   end
 
@@ -14,5 +14,9 @@ RSpec.describe Dry::Component::Namespace do
 
   it 'auto_register inside the namespace' do
     expect(subject['foos.bar']).to be_kind_of(Tests::Namespaced::Foos::Bar)
+  end
+
+  it 'works with auto inject' do
+    expect(Tests::Namespaced::Something.new.call).to be_kind_of(Tests::Namespaced::Imported)
   end
 end


### PR DESCRIPTION
An issue I'm getting with components is that I like to keep my code inside a single `module` which leads to file structures like:

```ruby
# To auto register operations inside:
#   my_app/components/sub_app/lib/my_app/sub_app/operations/**/*.rb
module MyApp::SubApp
  class Container < Dry::Component::Container
    configure do |config|
      config.root = ROOT.join('my_app/components/sub_app')
      config.auto_register = 'lib/my_app/sub_app/operations'
    end

    load_paths! 'lib'
  end
end

MyApp::SubApp::Container.finalize!
MyApp::SubApp::Container['my_app.sub_app.operations.some_operation']
```

This PR is a bare implementation of a Namespaced component.
The idea is that the component "knows" everything livies inside a module so it loads everything inside it.
So for example the same scenario from above would look more like:

```ruby
# To auto register all operations, now inside:
#   my_app/components/sub_app/operations/**/*.rb
module MyApp::SubApp
  extend Dry::Component::Namespace
  configure do |config|
    config.root = ROOT.join('my_app/components/sub_app')
    config.auto_register = 'operations'
  end
end

MyApp::SubApp.finalize!
MyApp::SubApp::Container['operations.some_operation']
```

Just wanted to see what you think about this concept before investing more time on the idea :wink: 