### PR TITLE
Fixes missing readme info about the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ require 'dry/component/container'
 
 class Application < Dry::Component::Container
   configure do |config|
-    config.root = '/my/app'
+    config.root = Pathname.new('./my/app')
   end
 end
 


### PR DESCRIPTION
After working with the code I found that I needed to pass a Pathname _and_ make it relative to the working directory with `./`. It's a minor thing but hopefully it'll help newcomers experimenting with this.

This is related to #7 