### PR TITLE
Allow for config to be erb processed

### DIFF
--- a/lib/dry/component/config.rb
+++ b/lib/dry/component/config.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module Dry
   module Component
@@ -8,7 +9,8 @@ module Dry
 
         return {} unless File.exist?(path)
 
-        yaml = YAML.load_file(path)
+        data = ERB.new(File.read(path)).result(binding)
+        yaml = YAML.load(data)
 
         Class.new do
           extend Dry::Configurable

--- a/spec/fixtures/test/config/application.yml
+++ b/spec/fixtures/test/config/application.yml
@@ -1,2 +1,3 @@
 test:
   foo: 'bar'
+  env: <%= ENV['USER'] %>

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -24,4 +24,8 @@ RSpec.describe Dry::Component::Config do
   it 'allows different components to have different configurations' do
     expect(Test::SubApp.options.bar).to eql('baz')
   end
+
+  it 'erb processes the config before passing to yaml' do
+    expect(Test::App.options.env).not_to be_nil
+  end
 end


### PR DESCRIPTION
In some deployment environment setups ([12factor](http://12factor.net/)) the application is expected to read its configuration information from the environment variables present on the system. By erb processing the config file in dry-component, it allows you to read the variables into application config (eg `DATABASE_URL`), and cleanly store constants (eg `max_upload_size`) in source control. 