### PR TITLE
Support all dry-auto_inject injector types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.1
   - rbx
   - jruby-9000
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - rbx-2
+  - rbx
   - jruby-9000
   - ruby-head
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'dry-container', github: 'dry-rb/dry-container', branch: 'hook-methods-via-modules'
+gem 'dry-container', github: 'dry-rb/dry-container'
 gem 'dry-auto_inject', github: 'dry-rb/dry-auto_inject'
 
 gem 'codeclimate-test-reporter', platforms: :rbx

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-auto_inject', github: 'dry-rb/dry-auto_inject'
+
 gem 'codeclimate-test-reporter', platforms: :rbx
 
 group :tools do

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-container', github: 'dry-rb/dry-container', branch: 'hook-methods-via-modules'
 gem 'dry-auto_inject', github: 'dry-rb/dry-auto_inject'
 
 gem 'codeclimate-test-reporter', platforms: :rbx

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -19,6 +19,11 @@ module Dry
       setting :auto_register
       setting :options
 
+      def self.inherited(subclass)
+        super
+        subclass.const_set :Inject, subclass.injector
+      end
+
       def self.configure(env = config.env, &block)
         return self if configured?
 
@@ -73,8 +78,8 @@ module Dry
         freeze
       end
 
-      def self.Inject
-        @Inject ||= Injector.new(self)
+      def self.injector
+        Injector.new(self)
       end
 
       def self.auto_register!(dir, &_block)

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -2,8 +2,8 @@ require 'pathname'
 require 'inflecto'
 
 require 'dry-container'
-require 'dry-auto_inject'
 
+require 'dry/component/injector'
 require 'dry/component/loader'
 require 'dry/component/config'
 
@@ -73,13 +73,8 @@ module Dry
         freeze
       end
 
-      def self.import_module
-        auto_inject = Dry::AutoInject(self)
-
-        -> *keys {
-          keys.each { |key| load_component(key) unless key?(key) }
-          auto_inject[*keys]
-        }
+      def self.Inject
+        @Inject ||= Injector.new(self)
       end
 
       def self.auto_register!(dir, &_block)

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -3,53 +3,74 @@ require "dry-auto_inject"
 module Dry
   module Component
     class Injector
+      class Strategy
+        # @api private
+        attr_reader :container
+
+        # @api private
+        attr_reader :injector
+
+        # @api private
+        def initialize(container, type)
+          @container = container
+          @injector = if type == :args
+            Dry::AutoInject(container)
+          else
+            Dry::AutoInject(container).send(type)
+          end
+        end
+
+        # @api public
+        def [](*deps)
+          load_components(*deps)
+          injector[*deps]
+        end
+
+        private
+
+        def load_components(*components)
+          components = components.dup
+          aliases = components.last.is_a?(Hash) ? components.pop : {}
+
+          (components + aliases.values).each do |key|
+            container.load_component(key) unless container.key?(key)
+          end
+        end
+      end
+
+      # @api private
       attr_reader :container
-      attr_reader :type
-      attr_reader :injector
 
       # @api private
       def initialize(container)
         @container = container
       end
 
-      # @api private
-      def injectors
-        @injectors ||= Hash.new do |h, injector_type|
-          h[injector_type] = if injector_type == :args
-            Dry::AutoInject(container)
-          else
-            Dry::AutoInject(container).send(injector_type)
-          end
-        end
+      # @api public
+      def [](*deps)
+        args[*deps]
       end
 
       # @api public
-      def args(*deps)
-        load_components(*deps)
-        injectors[:args][*deps]
-      end
-      alias_method :[], :args
-
-      # @api public
-      def hash(*deps)
-        load_components(*deps)
-        injectors[:hash][*deps]
+      def args
+        strategies[:args]
       end
 
       # @api public
-      def kwargs(*deps)
-        load_components(*deps)
-        injectors[:kwargs][*deps]
+      def hash
+        strategies[:hash]
+      end
+
+      # @api public
+      def kwargs
+        strategies[:kwargs]
       end
 
       private
 
-      def load_components(*components)
-        components = components.dup
-        aliases = components.last.is_a?(Hash) ? components.pop : {}
-
-        (components + aliases.values).each do |key|
-          container.load_component(key) unless container.key?(key)
+      def strategies
+        @strategies ||= Hash.new do |h, strategy_type|
+          Strategy.new(container, strategy_type)
         end
       end
     end

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -1,0 +1,57 @@
+require "dry-auto_inject"
+
+module Dry
+  module Component
+    class Injector
+      attr_reader :container
+      attr_reader :type
+      attr_reader :injector
+
+      # @api private
+      def initialize(container)
+        @container = container
+      end
+
+      # @api private
+      def injectors
+        @injectors ||= Hash.new do |h, injector_type|
+          h[injector_type] = if injector_type == :args
+            Dry::AutoInject(container)
+          else
+            Dry::AutoInject(container).send(injector_type)
+          end
+        end
+      end
+
+      # @api public
+      def args(*deps)
+        load_components(*deps)
+        injectors[:args][*deps]
+      end
+      alias_method :[], :args
+
+      # @api public
+      def hash(*deps)
+        load_components(*deps)
+        injectors[:hash][*deps]
+      end
+
+      # @api public
+      def kwargs(*deps)
+        load_components(*deps)
+        injectors[:kwargs][*deps]
+      end
+
+      private
+
+      def load_components(*components)
+        components = components.dup
+        aliases = components.last.is_a?(Hash) ? components.pop : {}
+
+        (components + aliases.values).each do |key|
+          container.load_component(key) unless container.key?(key)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
 
   config.before do
     @load_paths = $LOAD_PATH.dup
+    @loaded_features = $LOADED_FEATURES.dup
     Object.const_set(:Test, Module.new { |m| m.extend(TestNamespace) })
   end
 
@@ -40,6 +41,10 @@ RSpec.configure do |config|
     ($LOAD_PATH - @load_paths).each do |path|
       $LOAD_PATH.delete(path)
     end
+    ($LOADED_FEATURES - @loaded_features).each do |file|
+      $LOADED_FEATURES.delete(file)
+    end
+
     Test.remove_constants
     Object.send(:remove_const, :Test)
   end

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dry::Component::Container, '.import' do
       end
 
       module Test
-        Import = Container.Inject
+        Import = Container::Inject
       end
 
       class Test::Foo

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dry::Component::Container, '.import' do
       end
 
       module Test
-        Import = Container.import_module
+        Import = Container.Inject
       end
 
       class Test::Foo

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::Component::Container do
       end
 
       module Test
-        Import = Container.Inject
+        Import = Container::Inject
       end
     end
 

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::Component::Container do
       end
 
       module Test
-        Import = Container.import_module
+        Import = Container.Inject
       end
     end
 

--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Dry::Component::Injector do
+  before do
+    class Test::Container < Dry::Component::Container
+      configure do |config|
+        config.root = SPEC_ROOT.join("fixtures/test").realpath
+      end
+
+      load_paths! "lib"
+    end
+  end
+
+  it "supports args injection by default" do
+    obj = Class.new do
+      include Test::Container::Inject["test.dep"]
+    end.new
+
+    expect(obj.dep).to be_a Test::Dep
+  end
+
+  it "supports args injection with explicit method" do
+    obj = Class.new do
+      include Test::Container::Inject.args["test.dep"]
+    end.new
+
+    expect(obj.dep).to be_a Test::Dep
+  end
+
+  it "supports hash injection" do
+    obj = Class.new do
+      include Test::Container::Inject.hash["test.dep"]
+    end.new
+
+    expect(obj.dep).to be_a Test::Dep
+  end
+
+  it "support kwargs injection" do
+    obj = Class.new do
+      include Test::Container::Inject.kwargs["test.dep"]
+    end.new
+
+    expect(obj.dep).to be_a Test::Dep
+  end
+
+  it "supports aliases" do
+    obj = Class.new do
+      include Test::Container::Inject[foo: "test.dep"]
+    end.new
+
+    expect(obj.foo).to be_a Test::Dep
+  end
+end


### PR DESCRIPTION
Support all injector types offered by dry-auto_inject (args, hash, kwargs) while still auto-loading component files as required.

This changes `Container.import_module` to `Container.Inject`, which now returns an `Injector` object that offers API to inject with each of the strategies, e.g.

```ruby
class MyContainer < Dry::Component::Container
end

class MyClass
  # using plain args
  include MyContainer.Inject["foo.bar"]

  # using hash
  include MyContainer.Inject.hash["foo.bar"]

  # using kwargs
  include MyContainer.Inject.kwargs["foo.bar"]
end
```

The `Injector` also supports the new dry-auto_inject dependency aliasing API (e.g. `Inect[local_name: "container.name"]`).

This is a work in progress. I'm putting this PR up now for your feedback!

One change I would like to make is to be able to access the Injector via `::` syntax, e.g. `include MyContainer::Inject[*deps]`, but I'm not quite sure how to do that (or if it is even possible).