### PR TITLE
Cache injector strategies properly and allow arbitrary strategy swapping

### DIFF
--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Dry::Component::Injector do
     expect(obj.dep).to be_a Test::Dep
   end
 
+  it "allows injection strategies to be swapped" do
+    obj = Class.new do
+      include Test::Container::Inject.kwargs.hash["test.dep"]
+    end.new
+
+    expect(obj.dep).to be_a Test::Dep
+  end
+
   it "supports aliases" do
     obj = Class.new do
       include Test::Container::Inject[foo: "test.dep"]


### PR DESCRIPTION
Before, you could only declare an injector strategy once, e.g.

```ruby
MyContainer::Inject.kwargs["foo.bar"]
```

This would be fine if we accept that the standard "args" injector was the one everyone uses by default, e.g.

```ruby
MyApp::Import = MyContainer::Inject
class MyClass
  include MyApp::Import["foo.bar"]
end
```

However, this strategy swapping limitation would be a problem if you wanted to use an alternative default strategy. While this would work fine:

```ruby
MyApp::Import = MyContainer::Inject.kwargs
class MyClass
  include MyApp::Import["foo.bar"]
end
```

It would mean that you could then no longer swap strategies on a case by case basis:


```ruby
MyApp::Import = MyContainer::Inject.kwargs
class MyClass
  include MyApp::Import.hash["foo.bar"]
end
```

This change will allow this to work, by allowing strategy swaps to be chained arbitrarily (using a cache to make sure we're not needlessly creating injector objects for each swap).