### PR TITLE
Support all auto inject strategies

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -17,6 +17,7 @@ module Dry
       setting :root, Pathname.pwd.freeze
       setting :core_dir, 'component'.freeze
       setting :auto_register
+      setting :injector_options, {}
       setting :loader, Dry::Component::Loader
 
       def self.inherited(subclass)
@@ -64,7 +65,7 @@ module Dry
       end
 
       def self.injector
-        Injector.new(self)
+        Injector.new(self, config.injector_options)
       end
 
       def self.auto_register!(dir, &_block)

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -17,13 +17,7 @@ module Dry
       setting :root, Pathname.pwd.freeze
       setting :core_dir, 'component'.freeze
       setting :auto_register
-      setting :injector_options, {}
       setting :loader, Dry::Component::Loader
-
-      def self.inherited(subclass)
-        super
-        subclass.const_set :Inject, subclass.injector
-      end
 
       def self.configure(&block)
         super(&block)
@@ -64,8 +58,8 @@ module Dry
         freeze
       end
 
-      def self.injector
-        Injector.new(self, config.injector_options)
+      def self.injector(options = {})
+        Injector.new(self, options: options)
       end
 
       def self.auto_register!(dir, &_block)

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -2,7 +2,7 @@ require "dry-auto_inject"
 
 module Dry
   module Component
-    class Injector
+    class Injector < BasicObject
       # @api private
       attr_reader :container
 
@@ -10,14 +10,13 @@ module Dry
       attr_reader :injector
 
       # @api private
-      def initialize(container, strategy: nil, strategies_cache: nil)
+      def initialize(container, strategy: nil)
         @container = container
-        @strategies = strategies_cache
         @injector =
           if strategy
-            Dry::AutoInject(container).send(strategy)
+            ::Dry::AutoInject(container).send(strategy)
           else
-            Dry::AutoInject(container)
+            ::Dry::AutoInject(container)
           end
       end
 
@@ -27,35 +26,22 @@ module Dry
         injector[*deps]
       end
 
-      # @api public
-      def args
-        strategies[:args]
+      def method_missing(name, *args, &block)
+        ::Dry::Component::Injector.new(container, strategy: name)
       end
 
-      # @api public
-      def hash
-        strategies[:hash]
-      end
-
-      # @api public
-      def kwargs
-        strategies[:kwargs]
+      def respond_to_missing?(name, _include_private = false)
+        injector.respond_to?(name)
       end
 
       private
 
       def load_components(*components)
         components = components.dup
-        aliases = components.last.is_a?(Hash) ? components.pop : {}
+        aliases = components.last.is_a?(::Hash) ? components.pop : {}
 
         (components + aliases.values).each do |key|
           container.load_component(key) unless container.key?(key)
-        end
-      end
-
-      def strategies
-        @strategies ||= Hash.new do |cache, strategy|
-          cache[strategy] = self.class.new(container, strategy: strategy, strategies_cache: cache)
         end
       end
     end

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -29,8 +29,8 @@ module Dry
         ::Dry::Component::Injector.new(container, options: options, strategy: name)
       end
 
-      def respond_to_missing?(name, _include_private = false)
-        injector.respond_to?(name)
+      def respond_to?(name, include_private = false)
+        injector.respond_to?(name, include_private)
       end
 
       private

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -16,7 +16,7 @@ module Dry
       def initialize(container, options: {}, strategy: :default)
         @container = container
         @options = options
-        @injector = ::Dry::AutoInject(container, options).send(strategy)
+        @injector = ::Dry::AutoInject(container, options).public_send(strategy)
       end
 
       # @api public

--- a/lib/dry/component/injector.rb
+++ b/lib/dry/component/injector.rb
@@ -7,17 +7,16 @@ module Dry
       attr_reader :container
 
       # @api private
+      attr_reader :options
+
+      # @api private
       attr_reader :injector
 
       # @api private
-      def initialize(container, strategy: nil)
+      def initialize(container, options: {}, strategy: :default)
         @container = container
-        @injector =
-          if strategy
-            ::Dry::AutoInject(container).send(strategy)
-          else
-            ::Dry::AutoInject(container)
-          end
+        @options = options
+        @injector = ::Dry::AutoInject(container, options).send(strategy)
       end
 
       # @api public
@@ -27,7 +26,7 @@ module Dry
       end
 
       def method_missing(name, *args, &block)
-        ::Dry::Component::Injector.new(container, strategy: name)
+        ::Dry::Component::Injector.new(container, options: options, strategy: name)
       end
 
       def respond_to_missing?(name, _include_private = false)

--- a/spec/unit/container/import_spec.rb
+++ b/spec/unit/container/import_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dry::Component::Container, '.import' do
       end
 
       module Test
-        Import = Container::Inject
+        Import = Container.injector
       end
 
       class Test::Foo

--- a/spec/unit/container/injector_spec.rb
+++ b/spec/unit/container/injector_spec.rb
@@ -1,0 +1,29 @@
+require "dry/component/container"
+
+RSpec.describe Dry::Component::Container, ".injector" do
+  context "injector_options provided" do
+    it "builds an injector with the provided options" do
+      Test::Foo = Class.new
+
+      Test::Container = Class.new(Dry::Component::Container) do
+        register "foo", Test::Foo.new
+      end
+
+      Test::Inject = Test::Container.injector(strategies: {
+        default: Dry::AutoInject::Strategies::Args,
+        australian: Dry::AutoInject::Strategies::Args
+      })
+
+      injected_class = Class.new do
+        include Test::Inject.australian["foo"]
+      end
+
+      obj = injected_class.new
+      expect(obj.foo).to be_a Test::Foo
+
+      another = Object.new
+      obj = injected_class.new(another)
+      expect(obj.foo).to eq another
+    end
+  end
+end

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dry::Component::Container do
       end
 
       module Test
-        Import = Container::Inject
+        Import = Container.injector
       end
     end
 

--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe Dry::Component::Injector do
 
       load_paths! "lib"
     end
+
+    Test::Inject = Test::Container.injector
   end
 
   it "supports args injection by default" do
     obj = Class.new do
-      include Test::Container::Inject["test.dep"]
+      include Test::Inject["test.dep"]
     end.new
 
     expect(obj.dep).to be_a Test::Dep
@@ -19,7 +21,7 @@ RSpec.describe Dry::Component::Injector do
 
   it "supports args injection with explicit method" do
     obj = Class.new do
-      include Test::Container::Inject.args["test.dep"]
+      include Test::Inject.args["test.dep"]
     end.new
 
     expect(obj.dep).to be_a Test::Dep
@@ -27,7 +29,7 @@ RSpec.describe Dry::Component::Injector do
 
   it "supports hash injection" do
     obj = Class.new do
-      include Test::Container::Inject.hash["test.dep"]
+      include Test::Inject.hash["test.dep"]
     end.new
 
     expect(obj.dep).to be_a Test::Dep
@@ -35,7 +37,7 @@ RSpec.describe Dry::Component::Injector do
 
   it "support kwargs injection" do
     obj = Class.new do
-      include Test::Container::Inject.kwargs["test.dep"]
+      include Test::Inject.kwargs["test.dep"]
     end.new
 
     expect(obj.dep).to be_a Test::Dep
@@ -43,7 +45,7 @@ RSpec.describe Dry::Component::Injector do
 
   it "allows injection strategies to be swapped" do
     obj = Class.new do
-      include Test::Container::Inject.kwargs.hash["test.dep"]
+      include Test::Inject.kwargs.hash["test.dep"]
     end.new
 
     expect(obj.dep).to be_a Test::Dep
@@ -51,7 +53,7 @@ RSpec.describe Dry::Component::Injector do
 
   it "supports aliases" do
     obj = Class.new do
-      include Test::Container::Inject[foo: "test.dep"]
+      include Test::Inject[foo: "test.dep"]
     end.new
 
     expect(obj.foo).to be_a Test::Dep


### PR DESCRIPTION
Allow `Dry::AutoInject` options to be passed to `Dry::Component::Container#injector`. This allows the underlying auto_inject object to be configured as the user requires, while still retaining dry-component's desired behaviour of lazily loading dependencies.

The immediate benefit of this is that a user can now set up an injector with their own custom strategies container. However, it does mean that any options added to dry-auto_inject in the future will automatically be available for dry-component's injector as well.

This requires a breaking behavioural change, though. The `Inject` constant that we were setting up automatically on `Dry::Component::Container` subclasses can't be set up in the same way anymore, since there's no way we can infer by that time if the user wants any particular options to be passed. The recommended behaviour, instead, would be to have the user explicitly define their own constant to store their own preferred injector (e.g. `MyApp::Inject = MyApp::Container.injector(my_options)`). I think this is a reasonable requirement of users, though, and it was actually what we required of them until the last 0.3.0 release of dry-component, anyway.

Sound OK?