### PR TITLE
Add configurable default namespace to containers

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -14,6 +14,7 @@ module Dry
       extend Dry::Container::Mixin
 
       setting :name
+      setting :namespace
       setting :root, Pathname.pwd.freeze
       setting :core_dir, 'component'.freeze
       setting :auto_register
@@ -63,6 +64,10 @@ module Dry
         freeze
       end
 
+      def self.loader
+        @loader ||= config.loader.new(self)
+      end
+
       def self.injector
         Injector.new(self)
       end
@@ -72,7 +77,7 @@ module Dry
 
         Dir["#{root}/#{dir}/**/*.rb"].each do |path|
           component_path = path.to_s.gsub("#{dir_root}/", '').gsub('.rb', '')
-          config.loader.new(component_path).tap do |component|
+          loader.load(component_path).tap do |component|
             next if key?(component.identifier)
 
             Kernel.require component.path
@@ -121,7 +126,7 @@ module Dry
       end
 
       def self.load_component(key)
-        component = config.loader.new(key)
+        component = loader.load(key)
         src_key = component.namespaces[0]
 
         if imports.key?(src_key)

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -14,7 +14,7 @@ module Dry
       extend Dry::Container::Mixin
 
       setting :name
-      setting :namespace
+      setting :default_namespace
       setting :root, Pathname.pwd.freeze
       setting :core_dir, 'component'.freeze
       setting :auto_register
@@ -65,7 +65,7 @@ module Dry
       end
 
       def self.loader
-        @loader ||= config.loader.new(self)
+        @loader ||= config.loader.new(config)
       end
 
       def self.injector

--- a/lib/dry/component/loader.rb
+++ b/lib/dry/component/loader.rb
@@ -11,8 +11,8 @@ module Dry
           @loader = loader
 
           @identifier = input.to_s.gsub(loader.path_separator, loader.namespace_separator)
-          if loader.namespace
-            re = /^#{Regexp.escape(loader.namespace)}#{Regexp.escape(loader.namespace_separator)}/
+          if loader.default_namespace
+            re = /^#{Regexp.escape(loader.default_namespace)}#{Regexp.escape(loader.namespace_separator)}/
             @identifier = @identifier.gsub(re, '')
           end
 
@@ -41,13 +41,13 @@ module Dry
 
       PATH_SEPARATOR = '/'.freeze
 
-      attr_reader :namespace
+      attr_reader :default_namespace
       attr_reader :namespace_separator
       attr_reader :path_separator
 
-      def initialize(container)
-        @namespace = container.config.namespace
-        @namespace_separator = container.config.namespace_separator
+      def initialize(config)
+        @default_namespace = config.default_namespace
+        @namespace_separator = config.namespace_separator
         @path_separator = PATH_SEPARATOR
       end
 

--- a/lib/dry/component/loader.rb
+++ b/lib/dry/component/loader.rb
@@ -3,33 +3,56 @@ require 'inflecto'
 module Dry
   module Component
     class Loader
-      IDENTIFIER_SEPARATOR = '.'.freeze
+      class Component
+        attr_reader :loader
+        attr_reader :identifier, :path, :file
+
+        def initialize(loader, input)
+          @loader = loader
+
+          @identifier = input.to_s.gsub(loader.path_separator, loader.namespace_separator)
+          if loader.namespace
+            re = /^#{Regexp.escape(loader.namespace)}#{Regexp.escape(loader.namespace_separator)}/
+            @identifier = @identifier.gsub(re, '')
+          end
+
+          @path = input.to_s.gsub(loader.namespace_separator, loader.path_separator)
+          @file = "#{path}.rb"
+        end
+
+        def namespaces
+          identifier.split(loader.namespace_separator).map(&:to_sym)
+        end
+
+        def constant
+          Inflecto.constantize(constant_name)
+        end
+
+        def instance(*args)
+          constant.new(*args)
+        end
+
+        private
+
+        def constant_name
+          Inflecto.camelize(path)
+        end
+      end
+
       PATH_SEPARATOR = '/'.freeze
 
-      attr_reader :identifier, :path, :file
+      attr_reader :namespace
+      attr_reader :namespace_separator
+      attr_reader :path_separator
 
-      def initialize(input)
-        @identifier = input.to_s.gsub(PATH_SEPARATOR, IDENTIFIER_SEPARATOR)
-        @path = input.to_s.gsub(IDENTIFIER_SEPARATOR, PATH_SEPARATOR)
-        @file = "#{path}.rb"
+      def initialize(container)
+        @namespace = container.config.namespace
+        @namespace_separator = container.config.namespace_separator
+        @path_separator = PATH_SEPARATOR
       end
 
-      def namespaces
-        identifier.split(IDENTIFIER_SEPARATOR).map(&:to_sym)
-      end
-
-      def constant
-        Inflecto.constantize(name)
-      end
-
-      def instance(*args)
-        constant.new(*args)
-      end
-
-      private
-
-      def name
-        Inflecto.camelize(path)
+      def load(component_path)
+        Component.new(self, component_path)
       end
     end
   end

--- a/spec/fixtures/components/namespaced/bar.rb
+++ b/spec/fixtures/components/namespaced/bar.rb
@@ -1,0 +1,4 @@
+module Namespaced
+  class Bar
+  end
+end

--- a/spec/fixtures/components/namespaced/foo.rb
+++ b/spec/fixtures/components/namespaced/foo.rb
@@ -1,0 +1,4 @@
+module Namespaced
+  class Foo
+  end
+end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -1,7 +1,7 @@
 require 'dry/component/container'
 
 RSpec.describe Dry::Component::Container, '.auto_register!' do
-  context 'with the standard loader' do
+  context 'standard loader' do
     before do
       class Test::Container < Dry::Component::Container
         configure do |config|
@@ -18,15 +18,38 @@ RSpec.describe Dry::Component::Container, '.auto_register!' do
     it { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
   end
 
+  context 'standard loader with a default namespace configured' do
+    before do
+      class Test::Container < Dry::Component::Container
+        configure do |config|
+          config.root = SPEC_ROOT.join('fixtures').realpath
+          config.namespace = 'namespaced'
+        end
+
+        load_paths!('components')
+        auto_register!('components/namespaced')
+      end
+    end
+
+    specify { expect(Test::Container['foo']).to be_a(Namespaced::Foo) }
+    specify { expect(Test::Container['bar']).to be_a(Namespaced::Bar) }
+  end
+
   context 'with a custom loader' do
     before do
       class Test::Loader < Dry::Component::Loader
-        def identifier
-          super.gsub('.', '-')
+        class Component < Dry::Component::Loader::Component
+          def identifier
+            super + ".yay"
+          end
+
+          def instance(*args)
+            constant.respond_to?(:call) ? constant : constant.new(*args)
+          end
         end
 
-        def instance(*args)
-          constant.respond_to?(:call) ? constant : constant.new(*args)
+        def load(component_path)
+          Component.new(self, component_path)
         end
       end
 
@@ -41,9 +64,9 @@ RSpec.describe Dry::Component::Container, '.auto_register!' do
       end
     end
 
-    it { expect(Test::Container['foo']).to be_an_instance_of(Foo) }
-    it { expect(Test::Container['bar']).to eq(Bar) }
-    it { expect(Test::Container['bar'].call).to eq("Welcome to my Moe's Tavern!") }
-    it { expect(Test::Container['bar-baz']).to be_an_instance_of(Bar::Baz) }
+    it { expect(Test::Container['foo.yay']).to be_an_instance_of(Foo) }
+    it { expect(Test::Container['bar.yay']).to eq(Bar) }
+    it { expect(Test::Container['bar.yay'].call).to eq("Welcome to my Moe's Tavern!") }
+    it { expect(Test::Container['bar.baz.yay']).to be_an_instance_of(Bar::Baz) }
   end
 end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dry::Component::Container, '.auto_register!' do
       class Test::Container < Dry::Component::Container
         configure do |config|
           config.root = SPEC_ROOT.join('fixtures').realpath
-          config.namespace = 'namespaced'
+          config.default_namespace = 'namespaced'
         end
 
         load_paths!('components')

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -40,20 +40,23 @@ RSpec.describe Dry::Component::Loader do
     end
   end
 
+  let(:container) { Class.new(Dry::Component::Container) }
+  let(:loader) { Dry::Component::Loader.new(container) }
+
   context 'from identifier as a symbol' do
-    subject(:component) { Dry::Component::Loader.new(:'test.bar') }
+    subject(:component) { loader.load(:'test.bar') }
 
     it_behaves_like 'a valid component'
   end
 
   context 'from identifier as a string' do
-    subject(:component) { Dry::Component::Loader.new('test.bar') }
+    subject(:component) { loader.load('test.bar') }
 
     it_behaves_like 'a valid component'
   end
 
   context 'from path' do
-    subject(:component) { Dry::Component::Loader.new('test/bar') }
+    subject(:component) { loader.load('test/bar') }
 
     it_behaves_like 'a valid component'
   end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dry::Component::Loader do
   end
 
   let(:container) { Class.new(Dry::Component::Container) }
-  let(:loader) { Dry::Component::Loader.new(container) }
+  let(:loader) { Dry::Component::Loader.new(container.config) }
 
   context 'from identifier as a symbol' do
     subject(:component) { loader.load(:'test.bar') }


### PR DESCRIPTION
When a user sets a default namespace on a container, that namespace will not be used in any container registrations for components from within that namespace. This makes it easier to reference them later.

For example, in a container with a namespace of “foo.bar”, a component at “foo/bar/baz.rb” will be accessible on the identifier “baz” only (with the default namespace removed for convenience).

There are a few design adjustments to make this possible:

- The container's configured `loader` is instantiated with the container object being passed to it. This allows the loader to inspect the container for config and various other settings.
- The `loader` object no longer represents a single loaded component file, but instead should offer `#load(file)`, which _then_ returns an object to represent that loaded component file. This is what makes the previous change possible, making the loader a "service" which can inspect the container's config etc. as required.

Along with these structural changes, our default loader now checks for a `default_namespace` setting and will remove that from the front of any container identifiers that match. This gives us the ability to configure a container with `"my_app.foo"` as a namespace, and then access the component file `my_app/foo/bar.rb` as `Container["bar"]`. Yay!

It's probably worth comparing this to https://github.com/dry-rb/dry-component/pull/6 (👋 @sagmor) to see if there's anything from there we'd like to pull across or incorporate (or if we prefer that other implementation altogether).

What do you reckon?
