### PR TITLE
Return immediately from load_component if the key already exists

### DIFF
--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -123,6 +123,8 @@ module Dry
       end
 
       def self.load_component(key)
+        return if key?(key)
+
         component = loader.load(key)
         src_key = component.namespaces[0]
 

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -123,7 +123,7 @@ module Dry
       end
 
       def self.load_component(key)
-        return if key?(key)
+        return self if key?(key)
 
         component = loader.load(key)
         src_key = component.namespaces[0]
@@ -147,6 +147,8 @@ module Dry
             end
           end
         end
+
+        self
       end
 
       def self.require_component(component, &block)

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Dry::Component::Container do
 
         expect(Test::Foo.new.dep).to be_instance_of(Test::Dep)
       end
+
+      it "raises an error if a component's file can't be found" do
+        expect { container.load_component('test.missing') }.to raise_error Dry::Component::FileNotFoundError
+      end
+
+      it "is a no op if a matching component is already registered" do
+        container.register "test.no_matching_file", Object.new
+
+        expect { container.load_component("test.no_matching_file") }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
We ran into an issue with lazy loading when unit testing one of our in-development dry-web apps.

Here's the scenario. In a "main" sub-app (whose container imports our app's main umbrella container into the "core" namespace), we had an operation depend on one of the bootable dependencies from the umbrella container:

`apps/main/lib/main.subscribe_to_newsletter.rb`:

```ruby
require "main/import"

MyApp::Container.boot! :mailchimp

module Main
  class SubscribeToNewsletter
    include Main::Import["core.mailchimp"]
    
    def call(input)
      # do stuff with the input and pass it to the `mailchimp` object
    end
  end
end
```

The mailchimp dependency boot file looked like this:

`umbrella/boot/mailchimp.rb`:

```ruby
require "mailchimp"

MyApp::Container.register "mailchimp", Mailchimp::API.new(api_key_goes_here)
```

When unit testing `SubscribeToNewsletter` (i.e. when none of the containers had been finalized), it would try to lazily load the "core.mailchimp" dependency via `Dry::Container.load_component`. This call propagated up to the "core" container properly, but it would try to look for a `lib/mailchimp.rb` file, which does not exist, because that registration was already made by the boot file.

In this situation, it would crash with a `FileNotFoundError, "could not resolve require file for mailchimp"` error.

This is because while we had protections against trying to resolve alrady-registed files in `Injector#load_components` (the `unless container.key?(key)` part of [line 43](https://github.com/dry-rb/dry-component/blob/be8a0bbb401962899c2c92ad637640e5b8eddaa4/lib/dry/component/injector.rb#L43)), this would only work for the _immediate container_, not any containers that had been imported.

This is why we needed to move this check right into `Container.load_component`, so it can be made when components are loaded for both the immediate container and any imported containers.
