### PR TITLE
Re-PR: Add support for singletons with auto-register and auto-inject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 Gemfile.lock
+
+## Specific to RubyMine
+.idea

--- a/lib/dry/component/container.rb
+++ b/lib/dry/component/container.rb
@@ -80,7 +80,7 @@ module Dry
             Kernel.require component.path
 
             if block_given?
-              register(component.identifier, yield(component.constant))
+              register(component.identifier, yield(component))
             else
               register(component.identifier) { component.instance }
             end
@@ -138,7 +138,7 @@ module Dry
           import_container(src_key, src_container)
         else
           begin
-            require_component(component) { |klass| register(key) { klass.new } }
+            require_component(component) { |klass| register(key) { component.instance } }
           rescue FileNotFoundError => e
             if config.default_namespace
               load_component("#{config.default_namespace}#{config.namespace_separator}#{component.identifier}")

--- a/lib/dry/component/loader.rb
+++ b/lib/dry/component/loader.rb
@@ -29,7 +29,11 @@ module Dry
         end
 
         def instance(*args)
-          constant.new(*args)
+          if constant.respond_to?(:instance) && !constant.respond_to?(:new)
+            constant.instance(*args) # a singleton
+          else
+            constant.new(*args)
+          end
         end
 
         private

--- a/spec/fixtures/test/lib/test/singleton_dep.rb
+++ b/spec/fixtures/test/lib/test/singleton_dep.rb
@@ -1,0 +1,7 @@
+require 'singleton'
+
+module Test
+  class SingletonDep
+    include Singleton
+  end
+end

--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -58,4 +58,14 @@ RSpec.describe Dry::Component::Injector do
 
     expect(obj.foo).to be_a Test::Dep
   end
+
+  context "singleton" do
+    it "supports injection" do
+      obj = Class.new do
+        include Test::Container::Inject[foo: "test.singleton_dep"]
+      end.new
+
+      expect(obj.foo).to be_a Test::SingletonDep
+    end
+  end
 end

--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Dry::Component::Injector do
   context "singleton" do
     it "supports injection" do
       obj = Class.new do
-        include Test::Container::Inject[foo: "test.singleton_dep"]
+        include Test::Inject[foo: "test.singleton_dep"]
       end.new
 
       expect(obj.foo).to be_a Test::SingletonDep

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Dry::Component::Loader do
         end
       end
     end
-    subject(:component) { Dry::Component::Loader.new('test/bar') }
+    subject(:component) { loader.load(:'test.bar') }
 
     it_behaves_like 'a valid component'
   end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -64,15 +64,15 @@ RSpec.describe Dry::Component::Loader do
 
   context 'singleton' do
     before do
-        module Test
-          remove_const(:Bar)
-          class Bar
-            include Singleton
-          end
+      module Test
+        remove_const(:Bar)
+        class Bar
+          include Singleton
         end
       end
-      subject(:component) { Dry::Component::Loader.new('test/bar') }
-
-      it_behaves_like 'a valid component'
     end
+    subject(:component) { Dry::Component::Loader.new('test/bar') }
+
+    it_behaves_like 'a valid component'
+  end
 end

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -1,4 +1,5 @@
 require 'dry/component/loader'
+require 'singleton'
 
 RSpec.describe Dry::Component::Loader do
   before do
@@ -60,4 +61,18 @@ RSpec.describe Dry::Component::Loader do
 
     it_behaves_like 'a valid component'
   end
+
+  context 'singleton' do
+    before do
+        module Test
+          remove_const(:Bar)
+          class Bar
+            include Singleton
+          end
+        end
+      end
+      subject(:component) { Dry::Component::Loader.new('test/bar') }
+
+      it_behaves_like 'a valid component'
+    end
 end


### PR DESCRIPTION
@timriley @solnic 
I was able to get the PR cleaned up. This PR is based off rx/dry-component:master instead of the mucked up singleton_fix branch. I don't know if you are able to edit the head fork for the pull request (#21) on your end, but for me it is read only. So I re-opened (or re-PR'ed) it. 
Let me know if this needs anything more.