### PR TITLE
Refactor Container/Component/Loader

### DIFF
--- a/dry-system.gemspec
+++ b/dry-system.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_runtime_dependency 'inflecto', '>= 0.0.2'
+  spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-container', '~> 0.3', '>= 0.3.4'
   spec.add_runtime_dependency 'dry-auto_inject', '>= 0.4.0'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -29,6 +29,24 @@ module Dry
         freeze
       end
 
+      def bootable?(path)
+        boot_file(path).exist?
+      end
+
+      def boot_file(path)
+        path.join("#{root_key}.rb")
+      end
+
+      def file_exists?(paths)
+        paths.any? { |path| path.join(file).exist? }
+      end
+
+      def prepend(name)
+        self.class.new(
+          [name, identifier].join(separator), options.merge(loader: loader.class)
+        )
+      end
+
       def namespaced(namespace)
         self.class.new(
           path, options.merge(loader: loader.class, namespace: namespace)
@@ -41,11 +59,6 @@ module Dry
 
       def namespace
         options[:namespace]
-      end
-
-      def dependency?(name)
-        *deps, _ = namespaces
-        (deps & name.split(separator).map(&:to_sym)).size > 0
       end
 
       def root_key

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -14,6 +14,8 @@ module Dry
       def self.new(name, options)
         ns, sep = options.values_at(:namespace, :separator).map(&:to_s)
 
+        raise InvalidNamespaceError, ns if ns.include?(sep)
+
         identifier = name.to_s.scan(WORD_REGEX).reject { |s| ns == s }.join(sep)
         path = name.to_s.gsub(sep, PATH_SEPARATOR)
         loader = options.fetch(:loader, Loader).new(path)

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -16,7 +16,13 @@ module Dry
 
         raise InvalidNamespaceError, ns if ns.include?(sep)
 
-        identifier = name.to_s.scan(WORD_REGEX).reject { |s| ns == s }.join(sep)
+        keys = name.to_s.scan(WORD_REGEX)
+
+        if keys.uniq.size != keys.size
+          raise InvalidComponentError, name, 'duplicated keys in the name'
+        end
+
+        identifier = keys.reject { |s| ns == s }.join(sep)
         path = name.to_s.gsub(sep, PATH_SEPARATOR)
         loader = options.fetch(:loader, Loader).new(path)
 

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -20,6 +20,11 @@ module Dry
         @file = "#{path}.rb"
       end
 
+      def dependency?(name)
+        *deps, _ = namespaces
+        (deps & name.split(loader.namespace_separator).map(&:to_sym)).size > 0
+      end
+
       def root_key
         namespaces.first
       end

--- a/lib/dry/system/component.rb
+++ b/lib/dry/system/component.rb
@@ -2,6 +2,7 @@ require 'concurrent/map'
 
 require 'dry-equalizer'
 require 'dry/system/loader'
+require 'dry/system/errors'
 
 module Dry
   module System

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'inflecto'
 
 require 'dry-configurable'
 require 'dry-container'

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -185,16 +185,16 @@ module Dry
           src_key = component.root_key
 
           if imports.key?(src_key)
-            load_external_component(src_key, component.namespaced(src_key))
+            load_external_component(component.namespaced(src_key))
           else
-            load_local_component(key, component)
+            load_local_component(component)
           end
         end
 
         self
       end
 
-      def self.load_local_component(key, component)
+      def self.load_local_component(component)
         unless frozen?
           bootable_components
             .select { |dep| component.dependency?(dep) }
@@ -202,7 +202,7 @@ module Dry
         end
 
         require_component(component) do
-          register(key) { component.instance }
+          register(component.identifier) { component.instance }
         end
       rescue FileNotFoundError => e
         if config.default_namespace
@@ -213,10 +213,10 @@ module Dry
       end
       private_class_method :load_local_component
 
-      def self.load_external_component(key, component)
-        container = imports[key]
+      def self.load_external_component(component)
+        container = imports[component.namespace]
         container.load_component(component.identifier)
-        import_container(key, container)
+        import_container(component.namespace, container)
       end
       private_class_method :load_external_component
 

--- a/lib/dry/system/container.rb
+++ b/lib/dry/system/container.rb
@@ -11,6 +11,9 @@ require 'dry/system/component'
 module Dry
   module System
     class Container
+      RB_EXT = '.rb'.freeze
+      EMPTY_STRING = ''.freeze
+
       extend Dry::Configurable
       extend Dry::Container::Mixin
 
@@ -77,7 +80,7 @@ module Dry
         dir_root = root.join(dir.to_s.split('/')[0])
 
         Dir["#{root}/#{dir}/**/*.rb"].each do |path|
-          path = path.to_s.gsub("#{dir_root}/", '').gsub('.rb', '')
+          path = path.to_s.sub("#{dir_root}/", '').sub(RB_EXT, EMPTY_STRING)
 
           component(path).tap do |component|
             next if key?(component.identifier)

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -6,6 +6,13 @@ module Dry
       end
     end
 
+    ComponentLoadError = Class.new(StandardError) do
+      def initialize(component)
+        super("could not load component #{component.inspect}")
+      end
+    end
+
+
     InvalidComponentIdentifierError = Class.new(ArgumentError) do
       def initialize(name)
         super(

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -12,6 +12,11 @@ module Dry
       end
     end
 
+    InvalidNamespaceError = Class.new(StandardError) do
+      def initialize(ns)
+        super("Namespace #{ns} cannot include a separator")
+      end
+    end
 
     InvalidComponentIdentifierError = Class.new(ArgumentError) do
       def initialize(name)

--- a/lib/dry/system/errors.rb
+++ b/lib/dry/system/errors.rb
@@ -18,6 +18,14 @@ module Dry
       end
     end
 
+    InvalidComponentError = Class.new(ArgumentError) do
+      def initialize(name, reason = nil)
+        super(
+          "Tried to create an invalid #{name.inspect} component - #{reason}"
+        )
+      end
+    end
+
     InvalidComponentIdentifierError = Class.new(ArgumentError) do
       def initialize(name)
         super(

--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -1,28 +1,24 @@
-require 'dry/system/component'
+require 'inflecto'
 
 module Dry
   module System
     class Loader
-      PATH_SEPARATOR = '/'.freeze
+      attr_reader :path
 
-      attr_reader :default_namespace
-      attr_reader :namespace_separator
-      attr_reader :path_separator
-
-      def initialize(config)
-        @default_namespace = config.default_namespace
-        @namespace_separator = config.namespace_separator
-        @path_separator = PATH_SEPARATOR
+      def initialize(path)
+        @path = path
       end
 
-      def load(name)
-        Component.new(name, options)
+      def call(*args)
+        if constant.respond_to?(:instance) && !constant.respond_to?(:new)
+          constant.instance(*args) # a singleton
+        else
+          constant.new(*args)
+        end
       end
 
-      def options
-        { default_namespace: default_namespace,
-          namespace_separator: namespace_separator,
-          path_separator: path_separator }
+      def constant
+        Inflecto.constantize(Inflecto.classify(path))
       end
     end
   end

--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -15,8 +15,14 @@ module Dry
         @path_separator = PATH_SEPARATOR
       end
 
-      def load(path)
-        Component.new(self, path)
+      def load(name)
+        Component.new(name, options)
+      end
+
+      def options
+        { default_namespace: default_namespace,
+          namespace_separator: namespace_separator,
+          path_separator: path_separator }
       end
     end
   end

--- a/lib/dry/system/loader.rb
+++ b/lib/dry/system/loader.rb
@@ -10,8 +10,8 @@ module Dry
       end
 
       def call(*args)
-        if constant.respond_to?(:instance) && !constant.respond_to?(:new)
-          constant.instance(*args) # a singleton
+        if singleton?(constant)
+          constant.instance(*args)
         else
           constant.new(*args)
         end
@@ -19,6 +19,12 @@ module Dry
 
       def constant
         Inflecto.constantize(Inflecto.classify(path))
+      end
+
+      private
+
+      def singleton?(constant)
+        constant.respond_to?(:instance) && !constant.respond_to?(:new)
       end
     end
   end

--- a/spec/fixtures/umbrella/component/boot/db.rb
+++ b/spec/fixtures/umbrella/component/boot/db.rb
@@ -1,0 +1,10 @@
+Test::Umbrella.namespace(:db) do |container|
+  module Db
+    class Repo
+    end
+  end
+
+  container.finalize(:db) do
+    container.register(:repo, Db::Repo.new)
+  end
+end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -13,22 +13,51 @@ RSpec.describe 'Lazy-booting external deps' do
           config.name = :main
         end
       end
-
-      App.import(Umbrella)
-      Import = App.injector
     end
   end
 
-  let(:user_repo) do
-    Class.new { include Test::Import['core.db.repo'] }.new
+  shared_examples_for 'lazy booted dependency' do
+    it 'lazy boots an external dep provided by top-level container' do
+      expect(user_repo.repo).to be_instance_of(Db::Repo)
+    end
+
+    it 'loads an external dep during finalization' do
+      system.finalize!
+      expect(user_repo.repo).to be_instance_of(Db::Repo)
+    end
   end
 
-  it 'lazy boots an external dep provided by top-level container' do
-    expect(user_repo.repo).to be_instance_of(Db::Repo)
+  context 'when top-lvl container provide the depedency' do
+    let(:user_repo) do
+      Class.new { include Test::Import['core.db.repo'] }.new
+    end
+
+    let(:system) { Test::App }
+
+    before do
+      module Test
+        App.import(Umbrella)
+        Import = App.injector
+      end
+    end
+
+    it_behaves_like 'lazy booted dependency'
   end
 
-  it 'loads an external dep during finalization' do
-    Test::App.finalize!
-    expect(user_repo.repo).to be_instance_of(Db::Repo)
+  context 'when top-lvl container requires the dependency from the imported container' do
+    let(:user_repo) do
+      Class.new { include Test::Import['db.repo'] }.new
+    end
+
+    let(:system) { Test::Umbrella }
+
+    before do
+      module Test
+        Umbrella.import(App)
+        Import = Umbrella.injector
+      end
+    end
+
+    it_behaves_like 'lazy booted dependency'
   end
 end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Lazy-booting external deps' do
     end
   end
 
-  context 'when top-level container provides the depedency' do
+  context 'when top-level container provides the dependency' do
     let(:user_repo) do
       Class.new { include Test::Import['core.db.repo'] }.new
     end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Lazy-booting external deps' do
     end
   end
 
-  context 'when top-lvl container provide the depedency' do
+  context 'when top-level container provides the depedency' do
     let(:user_repo) do
       Class.new { include Test::Import['core.db.repo'] }.new
     end
@@ -44,7 +44,7 @@ RSpec.describe 'Lazy-booting external deps' do
     it_behaves_like 'lazy booted dependency'
   end
 
-  context 'when top-lvl container requires the dependency from the imported container' do
+  context 'when top-level container requires the dependency from the imported container' do
     let(:user_repo) do
       Class.new { include Test::Import['db.repo'] }.new
     end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'Lazy-booting external deps' do
+  before do
+    module Test
+      class Umbrella < Dry::System::Container
+        configure do |config|
+          config.name = :core
+          config.root = SPEC_ROOT.join('fixtures/umbrella').realpath
+        end
+      end
+
+      class App < Dry::System::Container
+        configure do |config|
+          config.name = :main
+        end
+      end
+
+      App.import(Umbrella)
+      Import = App.injector
+    end
+  end
+
+  let(:user_repo) do
+    Class.new { include Test::Import['core.db.repo'] }.new
+  end
+
+  it 'lazy boots an external dep provided by top-level container' do
+    expect(user_repo.repo).to be_instance_of(Db::Repo)
+  end
+
+  it 'loads an external dep during finalization' do
+    Test::App.finalize!
+    expect(user_repo.repo).to be_instance_of(Db::Repo)
+  end
+end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -29,23 +29,6 @@ RSpec.describe 'Lazy-booting external deps' do
 
   context 'when top-level container provides the dependency' do
     let(:user_repo) do
-      Class.new { include Test::Import['core.db.repo'] }.new
-    end
-
-    let(:system) { Test::App }
-
-    before do
-      module Test
-        App.import(Umbrella)
-        Import = App.injector
-      end
-    end
-
-    it_behaves_like 'lazy booted dependency'
-  end
-
-  context 'when top-level container requires the dependency from the imported container' do
-    let(:user_repo) do
       Class.new { include Test::Import['db.repo'] }.new
     end
 
@@ -55,6 +38,23 @@ RSpec.describe 'Lazy-booting external deps' do
       module Test
         Umbrella.import(App)
         Import = Umbrella.injector
+      end
+    end
+
+    it_behaves_like 'lazy booted dependency'
+  end
+
+  context 'when top-level container provides the dependency through import' do
+    let(:user_repo) do
+      Class.new { include Test::Import['core.db.repo'] }.new
+    end
+
+    let(:system) { Test::App }
+
+    before do
+      module Test
+        App.import(Umbrella)
+        Import = App.injector
       end
     end
 

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,24 +1,24 @@
 require 'dry/system/component'
 
 RSpec.describe Dry::System::Component do
-  subject(:component) { Dry::System::Component.new(name, separator: '.') }
+  subject(:component) { Dry::System::Component.new(name) }
 
   describe '.new' do
     it 'caches components' do
       create = -> {
-        Dry::System::Component.new('foo.bar', namespace: 'foo', separator: '.')
+        Dry::System::Component.new('foo.bar', namespace: 'foo')
       }
 
       expect(create.()).to be(create.())
     end
 
     it 'raises when namespace includes a separator' do
-      expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar', separator: '.') }
+      expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar') }
         .to raise_error(Dry::System::InvalidNamespaceError, /foo\.bar/)
     end
 
     it 'raises when identifier/path has duplicated keys' do
-      expect { Dry::System::Component.new('foo.bar.foo', namespace: 'foo', separator: '.') }
+      expect { Dry::System::Component.new('foo.bar.foo', namespace: 'foo') }
         .to raise_error(Dry::System::InvalidComponentError, /foo\.bar\.foo/)
     end
   end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Dry::System::Component do
       expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar', separator: '.') }
         .to raise_error(Dry::System::InvalidNamespaceError, /foo\.bar/)
     end
+
+    it 'raises when identifier/path has duplicated keys' do
+      expect { Dry::System::Component.new('foo.bar.foo', namespace: 'foo', separator: '.') }
+        .to raise_error(Dry::System::InvalidComponentError, /foo\.bar\.foo/)
+    end
   end
 
   context 'when name is a symbol' do

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,0 +1,42 @@
+require 'dry/system/component'
+
+RSpec.describe Dry::System::Component do
+  subject(:component) { Dry::System::Component.new(name, options) }
+
+  let(:options) do
+    { namespace_separator: namespace_separator, path_separator: path_separator }
+  end
+
+  let(:namespace_separator) { '.' }
+  let(:path_separator) { '/' }
+
+  context 'with default separators' do
+    let(:name) { :foo }
+
+    describe '#identifier' do
+      it 'returns qualified identifier' do
+        expect(component.identifier).to eql('foo')
+      end
+    end
+
+    describe '#namespaces' do
+      it 'returns namespace array' do
+        expect(component.namespaces).to eql(%i[foo])
+      end
+    end
+
+    describe '#root_key' do
+      it 'returns component key' do
+        expect(component.root_key).to be(:foo)
+      end
+    end
+
+    describe '#instance' do
+      it 'builds an instance' do
+        class Foo; end
+        expect(component.instance).to be_instance_of(Foo)
+        Object.send(:remove_const, :Foo)
+      end
+    end
+  end
+end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -1,21 +1,20 @@
 require 'dry/system/component'
 
 RSpec.describe Dry::System::Component do
-  subject(:component) { Dry::System::Component.new(name, options) }
+  subject(:component) { Dry::System::Component.new(name, separator: '.') }
 
-  let(:options) do
-    { namespace_separator: namespace_separator, path_separator: path_separator }
-  end
-
-  let(:namespace_separator) { '.' }
-  let(:path_separator) { '/' }
-
-  context 'with default separators' do
+  context 'when name is a symbol' do
     let(:name) { :foo }
 
     describe '#identifier' do
       it 'returns qualified identifier' do
         expect(component.identifier).to eql('foo')
+      end
+    end
+
+    describe '#namespace' do
+      it 'returns configured namespace' do
+        expect(component.namespace).to be(nil)
       end
     end
 
@@ -38,5 +37,62 @@ RSpec.describe Dry::System::Component do
         Object.send(:remove_const, :Foo)
       end
     end
+  end
+
+  shared_examples_for 'a valid component' do
+    describe '#identifier' do
+      it 'returns qualified identifier' do
+        expect(component.identifier).to eql('test.foo')
+      end
+    end
+
+    describe '#file' do
+      it 'returns relative path to the component file' do
+        expect(component.file).to eql('test/foo.rb')
+      end
+    end
+
+    describe '#namespace' do
+      it 'returns configured namespace' do
+        expect(component.namespace).to be(nil)
+      end
+    end
+
+    describe '#namespaces' do
+      it 'returns namespace array' do
+        expect(component.namespaces).to eql(%i[test foo])
+      end
+    end
+
+    describe '#root_key' do
+      it 'returns component key' do
+        expect(component.root_key).to be(:test)
+      end
+    end
+
+    describe '#instance' do
+      it 'builds an instance' do
+        module Test; class Foo; end; end
+        expect(component.instance).to be_instance_of(Test::Foo)
+      end
+    end
+  end
+
+  context 'when name is a path' do
+    let(:name) { 'test/foo' }
+
+    it_behaves_like 'a valid component'
+  end
+
+  context 'when name is a qualified string identifier' do
+    let(:name) { 'test.foo' }
+
+    it_behaves_like 'a valid component'
+  end
+
+  context 'when name is a qualified symbol identifier' do
+    let(:name) { :'test.foo' }
+
+    it_behaves_like 'a valid component'
   end
 end

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe Dry::System::Component do
       end
     end
 
-    describe '#namespaces' do
-      it 'returns namespace array' do
-        expect(component.namespaces).to eql(%i[foo])
-      end
-    end
-
     describe '#root_key' do
       it 'returns component key' do
         expect(component.root_key).to be(:foo)
@@ -58,9 +52,13 @@ RSpec.describe Dry::System::Component do
       end
     end
 
-    describe '#namespaces' do
-      it 'returns namespace array' do
-        expect(component.namespaces).to eql(%i[test foo])
+    describe '#namespaced' do
+      it 'returns a namespaced component' do
+        namespaced = component.namespaced(:test)
+
+        expect(namespaced.identifier).to eql('foo')
+        expect(namespaced.path).to eql('test/foo')
+        expect(namespaced.file).to eql('test/foo.rb')
       end
     end
 

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -3,6 +3,13 @@ require 'dry/system/component'
 RSpec.describe Dry::System::Component do
   subject(:component) { Dry::System::Component.new(name, separator: '.') }
 
+  describe '.new' do
+    it 'raises when namespace includes a separator' do
+      expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar', separator: '.') }
+        .to raise_error(Dry::System::InvalidNamespaceError, /foo\.bar/)
+    end
+  end
+
   context 'when name is a symbol' do
     let(:name) { :foo }
 

--- a/spec/unit/component_spec.rb
+++ b/spec/unit/component_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe Dry::System::Component do
   subject(:component) { Dry::System::Component.new(name, separator: '.') }
 
   describe '.new' do
+    it 'caches components' do
+      create = -> {
+        Dry::System::Component.new('foo.bar', namespace: 'foo', separator: '.')
+      }
+
+      expect(create.()).to be(create.())
+    end
+
     it 'raises when namespace includes a separator' do
       expect { Dry::System::Component.new('foo.bar.baz', namespace: 'foo.bar', separator: '.') }
         .to raise_error(Dry::System::InvalidNamespaceError, /foo\.bar/)

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -39,18 +39,8 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
   context 'with a custom loader' do
     before do
       class Test::Loader < Dry::System::Loader
-        class Component < Dry::System::Component
-          def identifier
-            super + ".yay"
-          end
-
-          def instance(*args)
-            constant.respond_to?(:call) ? constant : constant.new(*args)
-          end
-        end
-
-        def load(system_path)
-          Component.new(system_path, options)
+        def call(*args)
+          constant.respond_to?(:call) ? constant : constant.new(*args)
         end
       end
 
@@ -65,9 +55,9 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
       end
     end
 
-    it { expect(Test::Container['foo.yay']).to be_an_instance_of(Foo) }
-    it { expect(Test::Container['bar.yay']).to eq(Bar) }
-    it { expect(Test::Container['bar.yay'].call).to eq("Welcome to my Moe's Tavern!") }
-    it { expect(Test::Container['bar.baz.yay']).to be_an_instance_of(Bar::Baz) }
+    it { expect(Test::Container['foo']).to be_an_instance_of(Foo) }
+    it { expect(Test::Container['bar']).to eq(Bar) }
+    it { expect(Test::Container['bar'].call).to eq("Welcome to my Moe's Tavern!") }
+    it { expect(Test::Container['bar.baz']).to be_an_instance_of(Bar::Baz) }
   end
 end

--- a/spec/unit/container/auto_register_spec.rb
+++ b/spec/unit/container/auto_register_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
   context 'with a custom loader' do
     before do
       class Test::Loader < Dry::System::Loader
-        class System < Dry::System::Component
+        class Component < Dry::System::Component
           def identifier
             super + ".yay"
           end
@@ -50,7 +50,7 @@ RSpec.describe Dry::System::Container, '.auto_register!' do
         end
 
         def load(system_path)
-          System.new(self, system_path)
+          Component.new(system_path, options)
         end
       end
 

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe Dry::System::Container do
       end
 
       it "raises an error if a system's file can't be found" do
-        expect { container.load_component('test.missing') }.to raise_error Dry::System::FileNotFoundError
+        expect { container.load_component('test.missing') }.to raise_error(
+          Dry::System::ComponentLoadError, /test\.missing/
+        )
       end
 
       it "is a no op if a matching system is already registered" do

--- a/spec/unit/loader_spec.rb
+++ b/spec/unit/loader_spec.rb
@@ -2,82 +2,37 @@ require 'dry/system/loader'
 require 'singleton'
 
 RSpec.describe Dry::System::Loader do
-  before do
-    module Test
-      class Bar
-      end
-    end
-  end
+  let(:loader) { Dry::System::Loader.new('test/bar') }
 
-  shared_examples_for 'a valid component' do
-    describe '#constant' do
-      it 'returns the constant' do
-        expect(component.constant).to be(Test::Bar)
-      end
-    end
-
-    describe '#identifier' do
-      it 'returns container identifier' do
-        expect(component.identifier).to eql('test.bar')
-      end
-    end
-
-    describe '#path' do
-      it 'returns relative path to file defining the component constant' do
-        expect(component.path).to eql('test/bar')
-      end
-    end
-
-    describe '#file' do
-      it 'returns relative path to file with ext defining the component constant' do
-        expect(component.file).to eql('test/bar.rb')
-      end
-    end
-
-    describe '#instance' do
-      it 'builds a component class instance' do
-        expect(component.instance).to be_instance_of(Test::Bar)
-      end
-    end
-  end
-
-  let(:container) { Class.new(Dry::System::Container) }
-  let(:loader) { Dry::System::Loader.new(container.config) }
-
-  context 'from identifier as a symbol' do
-    subject(:component) { loader.load(:'test.bar') }
-
-    it_behaves_like 'a valid component'
-  end
-
-  context 'from identifier as a string' do
-    subject(:component) { loader.load('test.bar') }
-
-    it_behaves_like 'a valid component'
-  end
-
-  context 'from path' do
-    subject(:component) { loader.load('test/bar') }
-
-    it_behaves_like 'a valid component'
-  end
-
-  context 'singleton' do
-    subject(:component) { loader.load(:'test.bar') }
+  context 'not singleton' do
+    subject(:instance) { loader.call }
 
     before do
       module Test
-        remove_const(:Bar)
+        class Bar
+        end
+      end
+    end
+
+    it 'returns a new instance of the constant' do
+      expect(instance).to be_instance_of(Test::Bar)
+      expect(instance).not_to be(loader.call)
+    end
+  end
+
+  context 'singleton' do
+    subject(:instance) { loader.call }
+
+    before do
+      module Test
         class Bar
           include Singleton
         end
       end
     end
 
-    it_behaves_like 'a valid component'
-
     it 'returns singleton instance' do
-      expect(component.instance).to be(Test::Bar.instance)
+      expect(instance).to be(Test::Bar.instance)
     end
   end
 end


### PR DESCRIPTION
This improves separation of concerns and allows lazy-loading bootable deps.

## Summary

- [x] Move component-related logic from `System::Container` to `System::Component`
- [x] Refactor `System::Loader` into a simple class that is only responsible for object instantiation and is injected into components
- [x] Extend `System::Component` so that it can be namespace-aware
- [x] Make it possible that import module can trigger booting of a dependency